### PR TITLE
add guess_next_move tactic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 __pycache__
 
+# virtual environment for the guess_next_move Tactic
+
+/scripts/venv
+
 # Added by cargo
 
 /media

--- a/Chess.lean
+++ b/Chess.lean
@@ -1,5 +1,6 @@
 import Chess.Basic
 import Chess.Examples
 import Chess.Fen
+import Chess.NextMoveTactic
 import Chess.Tactics
 import Chess.Widgets

--- a/Chess/Examples.lean
+++ b/Chess/Examples.lean
@@ -1,5 +1,6 @@
 import Chess.Basic
 import Chess.Tactics
+import Chess.NextMoveTactic
 import Chess.Widgets
 
 
@@ -75,6 +76,29 @@ theorem smothered_mate :
     move "Qg8"
     opponent_move
     move "Nf7"
+    checkmate
+
+
+theorem smothered_mate' :
+    ForcedWin .white
+      ╔════════════════╗
+      ║▓▓░░▓▓░░♜]░░▓▓♚]║
+      ║♟]▓▓♟]♖]♙]▓▓♟]♟]║
+      ║▓▓░░♟]░░▓▓░░▓▓░░║
+      ║░░▓▓░░▓▓░░♟]♘]▓▓║
+      ║▓▓░░♕]░░▓▓░░♞]░░║
+      ║♛]▓▓░░▓▓░░▓▓♙]▓▓║
+      ║♙]░░▓▓░░♙]♙]▓▓♙]║
+      ║░░▓▓░░▓▓░░▓▓♔}▓▓║
+      ╚════════════════╝ := by
+  with_panel_widgets [ForcedWinWidget]
+    guess_next_move
+    opponent_move
+    guess_next_move
+    opponent_move
+    guess_next_move
+    opponent_move
+    guess_next_move
     checkmate
 
 

--- a/Chess/NextMoveTactic.lean
+++ b/Chess/NextMoveTactic.lean
@@ -1,0 +1,48 @@
+import Lean
+import Chess.Widgets
+
+open Lean Meta Elab Tactic Chess
+
+/-- Calls an external Python script and retrieves its output. -/
+def callNextMoveScript (input : String): IO String := do
+  let path := ("./scripts/get_next_move.py" : System.FilePath)
+  unless ← path.pathExists do
+    throw <| IO.userError s!"Python script '{path}' not found."
+  let out ← IO.Process.output { cmd := "python3", args := #[path.toString, input] }
+  if out.exitCode != 0 then
+    throw <| IO.userError s!"Script '{path}' exited with code {out.exitCode}:\n{out.stderr}"
+  return "move \"" ++ out.stdout.trim ++ "\""
+
+/-- A tactic that runs a Python script and uses its output as a Lean tactic.
+    Right now, this only works if `stockfish` is installed in your system.
+    If not, consider running
+    ```
+    sudo apt install stockfish
+    ```
+    -/
+elab "guess_next_move" : tactic => do
+  -- Get the current goal
+  let goal ← getMainGoal
+  -- Extract the position from a `ForcedWin` goal
+  let posOpt ← extractPositionFromForcedWinGoal goal
+  match posOpt with
+  | some posVal =>
+    -- Convert the position to a FEN string
+    let fenStr := fenFromPosition posVal
+    -- Pass the FEN string to the Python script
+    let nextMove ← liftM <| callNextMoveScript fenStr
+
+    -- Log the output for debugging
+    -- logInfo s!"Python script output: {nextMove}"
+
+    -- Interpret the Python output as Lean syntax and apply it
+    let env ← getEnv
+    match Parser.runParserCategory env `tactic nextMove with
+    | Except.error errMsg => throwError s!"Failed to parse tactic from Python script: {errMsg}"
+    | Except.ok stx => do
+      -- Add the suggestion to the tactic
+      Lean.Meta.Tactic.TryThis.addSuggestion (← getRef) nextMove
+
+      -- Execute the parsed tactic
+      evalTactic stx
+  | none => throwError "No ForcedWin goal found or invalid goal type."

--- a/scripts/get_next_move.py
+++ b/scripts/get_next_move.py
@@ -12,20 +12,17 @@ VENV_DIR = os.path.join(SCRIPT_DIR, 'venv')
 def create_virtualenv(venv_path):
     """Creates a virtual environment if it doesn't exist."""
     if not os.path.isdir(venv_path):
-        print("Creating virtual environment...")
         venv.create(venv_path, with_pip=True)
-        print(f"Virtual environment created at {venv_path}")
 
 def install_package(venv_path, package):
     """Installs a package in the virtual environment using pip."""
     pip_executable = os.path.join(venv_path, 'bin', 'pip')
     # Check if the package is already installed
     try:
-        subprocess.check_call([pip_executable, 'show', package], stdout=subprocess.DEVNULL)
+        subprocess.check_call([pip_executable, 'show', package], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except subprocess.CalledProcessError:
-        # Package is not installed; install it
-        print(f"Installing {package} in the virtual environment...")
-        subprocess.check_call([pip_executable, 'install', package])
+        # Package is not installed; install it silently
+        subprocess.check_call([pip_executable, 'install', package], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 def is_running_in_venv():
     """Checks if the script is already running inside the virtual environment."""

--- a/scripts/get_next_move.py
+++ b/scripts/get_next_move.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+import venv
+
+# Define the path to the script directory and virtual environment directory
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+VENV_DIR = os.path.join(SCRIPT_DIR, 'venv')
+
+def create_virtualenv(venv_path):
+    """Creates a virtual environment if it doesn't exist."""
+    if not os.path.isdir(venv_path):
+        print("Creating virtual environment...")
+        venv.create(venv_path, with_pip=True)
+        print(f"Virtual environment created at {venv_path}")
+
+def install_package(venv_path, package):
+    """Installs a package in the virtual environment using pip."""
+    pip_executable = os.path.join(venv_path, 'bin', 'pip')
+    # Check if the package is already installed
+    try:
+        subprocess.check_call([pip_executable, 'show', package], stdout=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        # Package is not installed; install it
+        print(f"Installing {package} in the virtual environment...")
+        subprocess.check_call([pip_executable, 'install', package])
+
+def is_running_in_venv():
+    """Checks if the script is already running inside the virtual environment."""
+    venv_python = os.path.join(VENV_DIR, 'bin', 'python3')
+    return os.path.realpath(sys.executable) == os.path.realpath(venv_python)
+
+def activate_and_run():
+    """Runs the chess move logic."""
+    # Install python-chess if not installed
+    install_package(VENV_DIR, 'python-chess')
+
+    # Now, import chess and the engine after ensuring installation
+    import chess
+    import chess.engine
+
+    if len(sys.argv) != 2:
+        print("Usage: get_next_move.py '<FEN>'")
+        sys.exit(1)
+
+    fen = sys.argv[1]
+    board = chess.Board(fen)
+
+    # Initialize the engine (specify the path if necessary)
+    engine = chess.engine.SimpleEngine.popen_uci('stockfish')
+
+    try:
+        # Set a thinking time limit (e.g., 0.1 seconds)
+        # TODO: make this an additional option here!
+        result = engine.play(board, chess.engine.Limit(time=.1))
+        move = result.move
+        # Output the move in Standard Algebraic Notation (e.g., "Nf3")
+        # Strip the '+', because we don't need it
+        print(board.san(move).replace('+', '').replace('#', ''))
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        engine.quit()
+
+def run_in_virtualenv():
+    """Re-executes the script using the virtual environment's Python."""
+    venv_python = os.path.join(VENV_DIR, 'bin', 'python3')
+
+    # If the current interpreter is not the virtual environment's python, re-execute the script
+    if not is_running_in_venv():
+        print("Re-executing the script within the virtual environment...")
+        os.execv(venv_python, [venv_python] + sys.argv)
+
+if __name__ == "__main__":
+    # Ensure the virtual environment is created
+    create_virtualenv(VENV_DIR)
+
+    # Check if we are running inside the virtual environment
+    if not is_running_in_venv():
+        run_in_virtualenv()
+    else:
+        activate_and_run()


### PR DESCRIPTION
This uses stockfish to find a suitable next for "self"  move when proving a `ForcedWin`.  It assumes that a binary called `stockfish` is in your path. 

I modeled it after the `polyrith` tactic, so you can click on `try this: move "foo"` and it will insert the suggestions. Right now it let's stockfish think for 0.1s, but we could make that adjustable of course.


![guess_next_move](https://github.com/user-attachments/assets/4426d8e2-b5a1-4525-937f-3449a73ceb5e)
