### PR TITLE
[BROKEN] An attempt at cleaning up the tree, and some lessons.

### DIFF
--- a/Input/Tutorial.lean
+++ b/Input/Tutorial.lean
@@ -5,3 +5,11 @@ theorem tutorial (a b c : Prop) (hab : a = b) (hc : c)
   constructor
   · rwa [←hab]
   · exact hc
+
+theorem test (p q : Prop) : p ∨ q → q ∨ p := by
+  intro h
+  obtain p | q := h
+  · right
+    exact p
+  · left
+    exact q


### PR DESCRIPTION
This does not work, and I think that going down this path might be a dead end. If we want to continue with this in the future, then I'd suggest leaving the part 1 code as a black box and simply massage the output tree in a subsequent function.

In particular, we seem to lose tactic information in this implementation: see NNG example.

Ideally, we get rid of some of the funny stuff, a la:

```lean
  | ``Lean.Parser.Tactic.tacticSeq =>
    -- let's just get rid of these; I don't think they're that important
    return acc
  | ``Lean.cdot =>
    -- bullet points don't need to be in the output
    return acc
```

The original code seems to have sequenced tactics as a flat list in a Node.seq variant. Maybe this code is helpful:
```lean
   return acc.foldr (fun node prev =>
      match node with
      | .node data _ =>
        [TacticStep.node data prev]
    ) []
```